### PR TITLE
fix: correct logical condition in ChartTooltipContent

### DIFF
--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -156,7 +156,7 @@ const ChartTooltipContent = React.forwardRef<
       labelKey,
     ]);
 
-    if (!active ?? !payload?.length) {
+    if (!active || !payload?.length) {
       return null;
     }
 


### PR DESCRIPTION
Update the condition in ChartTooltipContent to use a logical OR 
instead of a nullishalescing operator This change ensures that 
the tooltip correctly returns null when the active stateis false or the is empty, improving the component's 
behavior and preventing potential rendering issues.